### PR TITLE
voc格式标注转yolo格式标注的转换功能完善

### DIFF
--- a/toolbox/xml2txt_yolov3.py
+++ b/toolbox/xml2txt_yolov3.py
@@ -1,36 +1,85 @@
-import os 
+import os
 import argparse
 import xml.etree.ElementTree as ET
 from tqdm import tqdm
 
+
 def parse_opt():
-    parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--annotation_path', type=str, default='/root/LLVIP/Annotations', help='folder containing xml files')
-    parser.add_argument('--image_path', type=str, default='/root/LLVIP/infrared/train', help='image path, e.g. /root/LLVIP/infrared/train')
-    parser.add_argument('--txt_path', type=str, default='/root/yolov5/LLVIP/labels/train.txt', help='saving all bboxes of all images to a txt file')
+    parser = argparse.ArgumentParser(description='Convert LLVIP XML annotations to YOLO format in single txt file')
+    parser.add_argument('--annotation_path', type=str,
+                        default='/home/dataset/LLVIP/Annotations',
+                        help='folder containing xml files')
+    parser.add_argument('--image_path', type=str, default='/home/dataset/LLVIP/infrared/train',
+                        help='image path, e.g. /root/LLVIP/infrared/train')
+    parser.add_argument('--txt_path', type=str, default='/home/dataset/LLVIP/labels/a.txt',
+                        help='saving all bboxes of all images to a txt file')
     opt = parser.parse_args()
     return opt
+
+
 opt = parse_opt()
 
-def convert_LLVIP_annotation(anno_path,image_path,txt_path):
-    #anno_path: the path to the .xml file.
-    #image_path: the path to the .jpg file.
-    #txt_path: the path to the .txt file，you need to create a .txt file in advance.
-    with open(txt_path,'a') as f:
-        for i in tqdm(os.listdir(image_path)):
-            annotation=image_path+'/'+i
-            root=ET.parse(anno_path+'/'+i.split(".")[0]+'.xml').getroot()
-            objects = root.findall('object')
-            for obj in objects:
-                bbox = obj.find('bndbox')
-                xmin = bbox.find('xmin').text.strip()
-                xmax = bbox.find('xmax').text.strip()
-                ymin = bbox.find('ymin').text.strip()
-                ymax = bbox.find('ymax').text.strip()
-                annotation += ' ' + ','.join([xmin, ymin, xmax, ymax, str(0)])
-            f.write(annotation + "\n")
 
-anno_path=opt.annotation_path
-image_path=opt.image_path
-txt_path=opt.txt_path
-convert_LLVIP_annotation(anno_path,image_path,txt_path)
+def convert_LLVIP_annotation(anno_path, image_path, txt_path):
+    # 创建保存txt文件的目录
+    os.makedirs(os.path.dirname(txt_path), exist_ok=True)
+
+    # 清空并创建txt文件
+    with open(txt_path, 'w') as f:
+        pass
+
+    # 获取所有图像文件名
+    image_files = os.listdir(image_path)
+
+    for i in tqdm(image_files):
+        try:
+            # 获取图像文件名(不含扩展名)
+            img_name = i.split(".")[0]
+
+            # 构建对应的XML文件路径
+            xml_file = os.path.join(anno_path, img_name + '.xml')
+
+            # 检查XML文件是否存在
+            if not os.path.exists(xml_file):
+                print(f"警告: {xml_file} 不存在，跳过")
+                continue
+
+            # 解析XML文件
+            tree = ET.parse(xml_file)
+            root = tree.getroot()
+
+            # 获取所有对象
+            objects = root.findall('object')
+
+            # 构建当前图像的标注行
+            annotation = os.path.join(image_path, i)
+
+            # 处理每个对象
+            for obj in objects:
+                try:
+                    # 获取边界框坐标
+                    bbox = obj.find('bndbox')
+                    xmin = int(bbox.find('xmin').text.strip())
+                    ymin = int(bbox.find('ymin').text.strip())
+                    xmax = int(bbox.find('xmax').text.strip())
+                    ymax = int(bbox.find('ymax').text.strip())
+
+                    # 添加边界框信息到标注行
+                    annotation += f' {xmin},{ymin},{xmax},{ymax},0'
+                except Exception as e:
+                    print(f"警告: 处理 {xml_file} 中的对象时出错: {e}")
+                    continue
+
+            # 将标注行写入txt文件
+            with open(txt_path, 'a') as f:
+                f.write(annotation + "\n")
+
+        except Exception as e:
+            print(f"错误: 处理文件 {i} 时出错: {e}")
+            continue
+
+
+anno_path = opt.annotation_path
+image_path = opt.image_path
+txt_path = opt.txt_path
+convert_LLVIP_annotation(anno_path, image_path, txt_path)

--- a/toolbox/xml2txt_yolov5.py
+++ b/toolbox/xml2txt_yolov5.py
@@ -1,37 +1,93 @@
-import os 
+import os
 import argparse
 import xml.etree.ElementTree as ET
 from tqdm import tqdm
 
+
 def parse_opt():
-    parser = argparse.ArgumentParser(description='')
-    parser.add_argument('--annotation_path', type=str, default='/root/LLVIP/Annotations', help='folder containing xml files')
-    parser.add_argument('--image_path', type=str, default='/root/LLVIP/infrared/train', help='image path, e.g. /root/LLVIP/infrared/train')
-    parser.add_argument('--txt_save_path', type=str, default='/root/yolov5/LLVIP/labels/train', help='txt path containing txt files in yolov5 format')
+    parser = argparse.ArgumentParser(description='Convert LLVIP XML annotations to YOLOv5 format')
+    parser.add_argument('--annotation_path', type=str,
+                        default='/home/dataset/LLVIP/Annotations',
+                        help='folder containing xml files')
+    parser.add_argument('--image_path', type=str, default='/home/dataset/LLVIP/infrared/train',
+                        help='image path, e.g. /root/LLVIP/infrared/train')
+    parser.add_argument('--txt_save_path', type=str, default='/home/dataset/LLVIP/labels/train',
+                        help='txt path containing txt files in yolov5 format')
     opt = parser.parse_args()
     return opt
+
+
 opt = parse_opt()
 
-def convert_LLVIP_annotation(anno_path,image_path,txt_path):
-    for i in tqdm(os.listdir(image_path)):
-        root=ET.parse(anno_path+'/'+i.split(".")[0]+'.xml').getroot()
-        objects = root.findall('object')
-        for obj in objects:
-            annotation = ''
-            bbox = obj.find('bndbox')
-            xmin = int(bbox.find('xmin').text.strip())
-            xmax = int(bbox.find('xmax').text.strip())
-            ymin = int(bbox.find('ymin').text.strip())
-            ymax = int(bbox.find('ymax').text.strip())
-            x_center = str((0.5*(xmin + xmax))/1280)
-            y_center = str((0.5*(ymin + ymax))/1024)
-            width = str((xmax-xmin)/1280)
-            height = str((ymax-ymin)/1024)
-            annotation = annotation.join([str(0),' ',x_center,' ',y_center,' ',width,' ',height])
-            with open(txt_path+'/'+i.split(".")[0]+'.txt','a') as f:
-                f.write(annotation + "\n")
 
-anno_path=opt.annotation_path
-image_path=opt.image_path
-txt_path=opt.txt_save_path
-convert_LLVIP_annotation(anno_path,image_path,txt_path)
+def convert_LLVIP_annotation(anno_path, image_path, txt_path):
+    # 创建保存txt文件的目录
+    os.makedirs(txt_path, exist_ok=True)
+
+    # 获取所有图像文件名
+    image_files = os.listdir(image_path)
+
+    for i in tqdm(image_files):
+        try:
+            # 获取图像文件名(不含扩展名)
+            img_name = i.split(".")[0]
+
+            # 构建对应的XML文件路径
+            xml_file = os.path.join(anno_path, img_name + '.xml')
+
+            # 检查XML文件是否存在
+            if not os.path.exists(xml_file):
+                print(f"警告: {xml_file} 不存在，跳过")
+                continue
+
+            # 解析XML文件
+            tree = ET.parse(xml_file)
+            root = tree.getroot()
+
+            # 获取所有对象
+            objects = root.findall('object')
+
+            # 如果没有对象，创建空的txt文件
+            if not objects:
+                with open(os.path.join(txt_path, img_name + '.txt'), 'w') as f:
+                    pass
+                continue
+
+            # 处理每个对象
+            annotations = []
+            for obj in objects:
+                try:
+                    # 获取边界框坐标
+                    bbox = obj.find('bndbox')
+                    xmin = int(bbox.find('xmin').text.strip())
+                    xmax = int(bbox.find('xmax').text.strip())
+                    ymin = int(bbox.find('ymin').text.strip())
+                    ymax = int(bbox.find('ymax').text.strip())
+
+                    # 转换为YOLO格式
+                    x_center = (0.5 * (xmin + xmax)) / 1280
+                    y_center = (0.5 * (ymin + ymax)) / 1024
+                    width = (xmax - xmin) / 1280
+                    height = (ymax - ymin) / 1024
+
+                    # 构建标注行
+                    annotation = f"0 {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}"
+                    annotations.append(annotation)
+                except Exception as e:
+                    print(f"警告: 处理 {xml_file} 中的对象时出错: {e}")
+                    continue
+
+            # 将所有标注写入txt文件
+            if annotations:
+                with open(os.path.join(txt_path, img_name + '.txt'), 'w') as f:
+                    f.write('\n'.join(annotations) + '\n')
+
+        except Exception as e:
+            print(f"错误: 处理文件 {i} 时出错: {e}")
+            continue
+
+
+anno_path = opt.annotation_path
+image_path = opt.image_path
+txt_path = opt.txt_save_path
+convert_LLVIP_annotation(anno_path, image_path, txt_path)


### PR DESCRIPTION
完善voc格式标注转yolo格式标注的功能，之前的转换代码不包含对异常情况的处理和文件夹的自动检测与创建，最重要的是没有对没有目标的图像进行处理，导致没有目标的图像没有对于的转换后的.txt文件，比如训练图像有12025张图像，对应12025个.xml文件，但是使用原来的文件转换后只有12023